### PR TITLE
convert enum instance to value in toString()

### DIFF
--- a/templates/ObjectSerializer.mustache
+++ b/templates/ObjectSerializer.mustache
@@ -271,6 +271,8 @@ class ObjectSerializer
             return $value->format(self::$dateTimeFormat);
         } elseif (is_bool($value)) {
             return $value ? 'true' : 'false';
+        } elseif ($value instanceof \BackedEnum) {
+            return $value->value;
         } else {
             return (string) $value;
         }


### PR DESCRIPTION
related #5 

fixed error caused by ObjectSerializer when enum is used in path parameter.